### PR TITLE
[CORE-1730] Added UTF-8 encoding to python template

### DIFF
--- a/src/apps/Scripts/BaseScripts.js
+++ b/src/apps/Scripts/BaseScripts.js
@@ -37,6 +37,8 @@ const baseScripts = {
   },
   base_python: {
     source: `
+      # coding=UTF8
+
       # ARGS, CONFIG and META are three default dictionaries you
       # have access to from within the script. Click 'RUN' to see what
       # they contain. CONFIG is empty because you'd need to add key/values


### PR DESCRIPTION
This was not required before, but soon python script will be treated as a separate file (resulting in a proper traceback for one) so it needs to have encoding defined in case user uses UTF-8 in source.