### PR TITLE
[DASH-2334] Fix randomly failing plan usage e2e tests

### DIFF
--- a/test/e2e/tests/billing/testPlanUsage.js
+++ b/test/e2e/tests/billing/testPlanUsage.js
@@ -14,7 +14,8 @@ export default addTestNamePrefixes({
   afterEach: (client, done) => client.end(done),
   'User views Plan Usage': (client) => {
     const planUsagePage = client.page.planUsagePage();
-    const randomInstance = _.sample(instances).instanceName;
+    const instancesArray = _.filter(instances, 'instanceName');
+    const randomInstance = _.sample(instancesArray).instanceName;
     const usageChartsSelector = planUsagePage.elements.usageCharts.selector;
 
     planUsagePage


### PR DESCRIPTION
Plan usage e2e tests failed randomly because we used lodash sample on whole instances object, where in fact there is also account information in it. So tests had about 25% to choose account information that didn't have information about instance name, thus failing.