### PR TITLE
[DASH-2395] Remove generation of jest tests from npm test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
   },
   "scripts": {
     "start": "gulp webpack-dev-server",
-    "test": "react-snapshot-test-generator && jest --config jest.json",
+    "test": "jest --config jest.json",
+    "generate-snapshot": "react-snapshot-test-generator",
     "build": "gulp build",
     "publish": "gulp publish",
     "clean": "gulp clean",


### PR DESCRIPTION
Now tests won't be generated on circle thus deploy on master won't fail.

It was done same way that lint tests, lint auto-fixed dashboard on circle ci, same jest generated new tests and thus timestamp changed.